### PR TITLE
XDR-3403: Update Terraform's Azuread provider to 2.x

### DIFF
--- a/examples/azuread-application/main.tf
+++ b/examples/azuread-application/main.tf
@@ -11,7 +11,7 @@ terraform {
 module "azuread_application" {
   source = "../../modules/azuread-application"
 
-  display_name                            = var.name
+  display_name                            = var.display_name
   homepage_url                            = var.homepage_url
   identifier_uris                         = var.identifier_uris
   redirect_uris                           = var.redirect_uris

--- a/examples/azuread-application/main.tf
+++ b/examples/azuread-application/main.tf
@@ -11,7 +11,7 @@ terraform {
 module "azuread_application" {
   source = "../../modules/azuread-application"
 
-  name                                    = var.name
+  display_name                            = var.name
   homepage_url                            = var.homepage_url
   identifier_uris                         = var.identifier_uris
   redirect_uris                           = var.redirect_uris

--- a/examples/azuread-application/main.tf
+++ b/examples/azuread-application/main.tf
@@ -1,9 +1,9 @@
 terraform {
   required_version = ">= 0.12.26"
   required_providers {
-    aws = {
+    azuread = {
       source  = "hashicorp/azuread"
-      version = "1.3.0"
+      version = "2.22.0"
     }
   }
 }
@@ -11,15 +11,15 @@ terraform {
 module "azuread_application" {
   source = "../../modules/azuread-application"
 
-  name                       = var.name
-  homepage                   = var.homepage
-  identifier_uris            = var.identifier_uris
-  reply_urls                 = var.reply_urls
-  logout_url                 = var.logout_url
-  available_to_other_tenants = var.available_to_other_tenants
-  public_client              = var.public_client
-  oauth2_allow_implicit_flow = var.oauth2_allow_implicit_flow
-  group_membership_claims    = var.group_membership_claims
-  owners                     = var.owners
-  oauth2_permissions         = var.oauth2_permissions
+  name                                    = var.name
+  homepage_url                            = var.homepage_url
+  identifier_uris                         = var.identifier_uris
+  redirect_uris                           = var.redirect_uris
+  logout_url                              = var.logout_url
+  sign_in_audience                        = var.sign_in_audience
+  fallback_public_client_enabled          = var.fallback_public_client_enabled
+  oauth2_implicit_flow_allow_access_token = var.oauth2_implicit_flow_allow_access_token
+  group_membership_claims                 = var.group_membership_claims
+  owners                                  = var.owners
+  oauth2_permission_scopes                = var.oauth2_permission_scopes
 }

--- a/examples/azuread-application/vars.tf
+++ b/examples/azuread-application/vars.tf
@@ -1,4 +1,4 @@
-variable "name" {
+variable "display_name" {
   description = "The display name for the application."
   type        = string
   default     = "test-azuread-application"

--- a/examples/azuread-application/vars.tf
+++ b/examples/azuread-application/vars.tf
@@ -4,7 +4,7 @@ variable "name" {
   default     = "test-azuread-application"
 }
 
-variable "homepage" {
+variable "homepage_url" {
   description = "The URL to the application's home page. If no homepage is specified this defaults to `https://{name}`."
   type        = string
   default     = null
@@ -16,7 +16,7 @@ variable "identifier_uris" {
   default     = []
 }
 
-variable "reply_urls" {
+variable "redirect_uris" {
   description = "A set of URLs that user tokens are sent to for sign in, or the redirect URIs that OAuth 2.0 authorization codes and access tokens are sent to."
   type        = set(string)
   default     = []
@@ -28,19 +28,19 @@ variable "logout_url" {
   default     = null
 }
 
-variable "available_to_other_tenants" {
+variable "sign_in_audience" {
   description = "Whether or not this Azure AD application is available to other tenants."
-  type        = bool
-  default     = false
+  type        = string
+  default     = "AzureADMyOrg"
 }
 
-variable "public_client" {
+variable "fallback_public_client_enabled" {
   description = "Whether or not this Azure AD application is a public client."
   type        = bool
   default     = false
 }
 
-variable "oauth2_allow_implicit_flow" {
+variable "oauth2_implicit_flow_allow_access_token" {
   description = "Whether or not the OAuth 2.0 implicit flow is allowed for this application."
   type        = bool
   default     = false
@@ -58,14 +58,14 @@ variable "owners" {
   default     = null
 }
 
-variable "oauth2_permissions" {
+variable "oauth2_permission_scopes" {
   description = "A set of OAuth 2.0 permission scopes granted to clients."
   type = set(object({
     admin_consent_description  = string
     admin_consent_display_name = string
     value                      = string
     type                       = string
-    is_enabled                 = bool
+    enabled                    = bool
     user_consent_description   = string
     user_consent_display_name  = string
   }))

--- a/examples/azuread-application/vars.tf
+++ b/examples/azuread-application/vars.tf
@@ -60,7 +60,7 @@ variable "owners" {
 
 variable "oauth2_permission_scopes" {
   description = "A set of OAuth 2.0 permission scopes granted to clients."
-  type = set(object({
+  type = map(object({
     admin_consent_description  = string
     admin_consent_display_name = string
     value                      = string
@@ -69,5 +69,15 @@ variable "oauth2_permission_scopes" {
     user_consent_description   = string
     user_consent_display_name  = string
   }))
-  default = []
+  default = {
+    scope1 = {
+      admin_consent_description  = "Allow the application to access example on behalf of the signed-in user"
+      admin_consent_display_name = "Access example"
+      value                      = "user_impersonation"
+      type                       = "User"
+      enabled                    = true
+      user_consent_description   = "Allow the application to access example on your behalf."
+      user_consent_display_name  = "Access example"
+    }
+  }
 }

--- a/examples/azuread-application/vars.tf
+++ b/examples/azuread-application/vars.tf
@@ -48,8 +48,8 @@ variable "oauth2_implicit_flow_allow_access_token" {
 
 variable "group_membership_claims" {
   description = "Configures the `groups` claim issued in a user or OAuth 2.0 access token that the app expects. One of `None`, `SecurityGroup`, `DirectoryRole`, `ApplicationGroup`, or `All`."
-  type        = string
-  default     = null
+  type        = set(string)
+  default     = []
 }
 
 variable "owners" {

--- a/examples/azuread-service-principal/main.tf
+++ b/examples/azuread-service-principal/main.tf
@@ -9,8 +9,8 @@ terraform {
 }
 
 module "azuread_app" {
-  source = "../../modules/azuread-application"
-  name   = "exampleadapplication"
+  source       = "../../modules/azuread-application"
+  display_name = "exampleadapplication"
 }
 
 module "azuread-service-principal" {

--- a/examples/azuread-service-principal/main.tf
+++ b/examples/azuread-service-principal/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 0.12.26"
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "2.22.0"
+    }
+  }
+}
+
+module "azuread_app" {
+  source = "../../modules/azuread-application"
+  name   = "exampleadapplication"
+}
+
+module "azuread-service-principal" {
+  source = "../../modules/azuread-service-principal"
+
+  application_id = module.azuread_app.application_id
+}
+
+output "password" {
+  value     = module.azuread-service-principal.password
+  sensitive = true
+}
+
+output "key_id" {
+  value = module.azuread-service-principal.password_key_id
+}

--- a/modules/azuread-application/main.tf
+++ b/modules/azuread-application/main.tf
@@ -14,7 +14,7 @@ terraform {
 }
 
 resource "azuread_application" "app" {
-  display_name    = var.name
+  display_name    = var.display_name
   identifier_uris = var.identifier_uris
 
   group_membership_claims = var.group_membership_claims == null ? [] : [var.group_membership_claims]

--- a/modules/azuread-application/main.tf
+++ b/modules/azuread-application/main.tf
@@ -17,7 +17,7 @@ resource "azuread_application" "app" {
   display_name    = var.display_name
   identifier_uris = var.identifier_uris
 
-  group_membership_claims = var.group_membership_claims == null ? [] : [var.group_membership_claims]
+  group_membership_claims = var.group_membership_claims
   owners                  = var.owners
 
   sign_in_audience               = var.sign_in_audience

--- a/modules/azuread-application/main.tf
+++ b/modules/azuread-application/main.tf
@@ -8,34 +8,45 @@ terraform {
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 1.3"
+      version = "~> 2.22"
     }
   }
 }
 
 resource "azuread_application" "app" {
-  display_name               = var.name
-  homepage                   = var.homepage
-  identifier_uris            = var.identifier_uris
-  reply_urls                 = var.reply_urls
-  logout_url                 = var.logout_url
-  available_to_other_tenants = var.available_to_other_tenants
-  public_client              = var.public_client
-  oauth2_allow_implicit_flow = var.oauth2_allow_implicit_flow
-  group_membership_claims    = var.group_membership_claims
-  owners                     = var.owners
+  display_name    = var.name
+  identifier_uris = var.identifier_uris
 
-  dynamic "oauth2_permissions" {
-    for_each = var.oauth2_permissions
+  group_membership_claims = var.group_membership_claims == null ? [] : [var.group_membership_claims]
+  owners                  = var.owners
 
-    content {
-      admin_consent_description  = oauth2_permissions.value.admin_consent_description
-      admin_consent_display_name = oauth2_permissions.value.admin_consent_display_name
-      value                      = oauth2_permissions.value.value
-      type                       = oauth2_permissions.value.type
-      is_enabled                 = oauth2_permissions.value.is_enabled
-      user_consent_description   = oauth2_permissions.value.user_consent_description
-      user_consent_display_name  = oauth2_permissions.value.user_consent_display_name
+  sign_in_audience               = var.sign_in_audience
+  fallback_public_client_enabled = var.fallback_public_client_enabled
+
+  web {
+    homepage_url  = var.homepage_url
+    logout_url    = var.logout_url
+    redirect_uris = var.redirect_uris
+
+    implicit_grant {
+      access_token_issuance_enabled = var.oauth2_implicit_flow_allow_access_token
+    }
+  }
+
+  api {
+    dynamic "oauth2_permission_scope" {
+      for_each = var.oauth2_permission_scopes
+
+      content {
+        admin_consent_description  = oauth2_permission_scope.value.admin_consent_description
+        admin_consent_display_name = oauth2_permission_scope.value.admin_consent_display_name
+        value                      = oauth2_permission_scope.value.value
+        type                       = oauth2_permission_scope.value.type
+        enabled                    = oauth2_permission_scope.value.enabled
+        user_consent_description   = oauth2_permission_scope.value.user_consent_description
+        user_consent_display_name  = oauth2_permission_scope.value.user_consent_display_name
+        id                         = uuid()
+      }
     }
   }
 }

--- a/modules/azuread-application/main.tf
+++ b/modules/azuread-application/main.tf
@@ -10,7 +10,15 @@ terraform {
       source  = "hashicorp/azuread"
       version = "~> 2.22"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.2"
+    }
   }
+}
+
+resource "random_uuid" "oauth2_permission_scope_id" {
+  for_each = var.oauth2_permission_scopes
 }
 
 resource "azuread_application" "app" {
@@ -45,7 +53,7 @@ resource "azuread_application" "app" {
         enabled                    = oauth2_permission_scope.value.enabled
         user_consent_description   = oauth2_permission_scope.value.user_consent_description
         user_consent_display_name  = oauth2_permission_scope.value.user_consent_display_name
-        id                         = uuid()
+        id                         = random_uuid.oauth2_permission_scope_id[oauth2_permission_scope.key].result
       }
     }
   }

--- a/modules/azuread-application/vars.tf
+++ b/modules/azuread-application/vars.tf
@@ -56,8 +56,12 @@ variable "oauth2_implicit_flow_allow_access_token" {
 
 variable "group_membership_claims" {
   description = "Configures the `groups` claim issued in a user or OAuth 2.0 access token that the app expects. One of `None`, `SecurityGroup`, `DirectoryRole`, `ApplicationGroup`, or `All`."
-  type        = string
-  default     = null
+  type        = set(string)
+  validation {
+    condition     = can([for c in var.group_membership_claims : contains(["None", "SecurityGroup", "DirectoryRole", "ApplicationGroup", "All"], c)])
+    error_message = "Allowed values for input_parameter are \"None\", \"SecurityGroup\", \"DirectoryRole\", \"ApplicationGroup\" or \"All\"."
+  }
+  default = []
 }
 
 variable "owners" {

--- a/modules/azuread-application/vars.tf
+++ b/modules/azuread-application/vars.tf
@@ -3,7 +3,7 @@ variable "name" {
   type        = string
 }
 
-variable "homepage" {
+variable "homepage_url" {
   description = "The URL to the application's home page. If no homepage is specified this defaults to `https://{name}`."
   type        = string
   default     = null
@@ -15,7 +15,7 @@ variable "identifier_uris" {
   default     = []
 }
 
-variable "reply_urls" {
+variable "redirect_uris" {
   description = "A set of URLs that user tokens are sent to for sign in, or the redirect URIs that OAuth 2.0 authorization codes and access tokens are sent to."
   type        = set(string)
   default     = []
@@ -27,20 +27,29 @@ variable "logout_url" {
   default     = null
 }
 
-variable "available_to_other_tenants" {
-  description = "Whether or not this Azure AD application is available to other tenants."
-  type        = bool
-  default     = false
+variable "sign_in_audience" {
+  description = "The Microsoft account types that are supported for the current application."
+  type        = string
+  default     = "AzureADMyOrg"
+  validation {
+    condition = contains([
+      "AzureADMyOrg",
+      "AzureADMultipleOrgs",
+      "AzureADandPersonalMicrosoftAccount",
+      "PersonalMicrosoftAccount"],
+    var.sign_in_audience)
+    error_message = "Allowed values for input_parameter are \"AzureADMyOrg\", \"AzureADMultipleOrgs\", \"AzureADandPersonalMicrosoftAccount\" or \"PersonalMicrosoftAccount\"."
+  }
 }
 
-variable "public_client" {
+variable "fallback_public_client_enabled" {
   description = "Whether or not this Azure AD application is a public client."
   type        = bool
   default     = false
 }
 
-variable "oauth2_allow_implicit_flow" {
-  description = "Whether or not the OAuth 2.0 implicit flow is allowed for this application."
+variable "oauth2_implicit_flow_allow_access_token" {
+  description = "Whether or not application can request an access token using OAuth 2.0 implicit flow."
   type        = bool
   default     = false
 }
@@ -57,14 +66,14 @@ variable "owners" {
   default     = null
 }
 
-variable "oauth2_permissions" {
+variable "oauth2_permission_scopes" {
   description = "A set of OAuth 2.0 permission scopes granted to clients."
   type = set(object({
     admin_consent_description  = string
     admin_consent_display_name = string
     value                      = string
     type                       = string
-    is_enabled                 = bool
+    enabled                    = bool
     user_consent_description   = string
     user_consent_display_name  = string
   }))

--- a/modules/azuread-application/vars.tf
+++ b/modules/azuread-application/vars.tf
@@ -1,4 +1,4 @@
-variable "name" {
+variable "display_name" {
   description = "The display name for the application."
   type        = string
 }

--- a/modules/azuread-application/vars.tf
+++ b/modules/azuread-application/vars.tf
@@ -72,7 +72,7 @@ variable "owners" {
 
 variable "oauth2_permission_scopes" {
   description = "A set of OAuth 2.0 permission scopes granted to clients."
-  type = set(object({
+  type = map(object({
     admin_consent_description  = string
     admin_consent_display_name = string
     value                      = string
@@ -81,5 +81,5 @@ variable "oauth2_permission_scopes" {
     user_consent_description   = string
     user_consent_display_name  = string
   }))
-  default = []
+  default = {}
 }

--- a/modules/azuread-service-principal/main.tf
+++ b/modules/azuread-service-principal/main.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 1.3"
+      version = "~> 2.22"
     }
 
     random = {
@@ -16,12 +16,6 @@ terraform {
       version = "~> 3.0"
     }
   }
-}
-
-resource "random_password" "service_principal_password" {
-  length           = 32
-  special          = true
-  override_special = "._"
 }
 
 resource "azuread_service_principal" "service_principal" {
@@ -33,6 +27,6 @@ resource "azuread_service_principal_password" "password" {
   depends_on = [azuread_service_principal.service_principal]
 
   service_principal_id = azuread_service_principal.service_principal.id
-  value                = var.password != null ? var.password : random_password.service_principal_password.result
-  end_date_relative    = var.end_date_relative
+
+  end_date_relative = var.end_date_relative
 }

--- a/modules/azuread-service-principal/outputs.tf
+++ b/modules/azuread-service-principal/outputs.tf
@@ -25,7 +25,7 @@ output "password_key_id" {
 }
 
 output "password" {
-  description = "The randomly generated password for this service principal."
+  description = "The randomly generated password by Azure Active Directory for this service principal."
   value       = azuread_service_principal_password.password.value
   sensitive   = true
 }

--- a/modules/azuread-service-principal/outputs.tf
+++ b/modules/azuread-service-principal/outputs.tf
@@ -18,18 +18,14 @@ output "app_role_assignment_required" {
   value       = azuread_service_principal.service_principal.app_role_assignment_required
 }
 
-output "oauth2_permissions" {
-  description = "A collection of OAuth 2.0 permissions exposed by the associated application."
-  value       = azuread_service_principal.service_principal.oauth2_permissions
-}
 
 output "password_key_id" {
   description = "The key ID for the service principal password."
-  value       = azuread_service_principal_password.password.id
+  value       = azuread_service_principal_password.password.key_id
 }
 
 output "password" {
   description = "The randomly generated password for this service principal."
-  value       = var.password == null ? random_password.service_principal_password.result : null
+  value       = azuread_service_principal_password.password.value
   sensitive   = true
 }

--- a/modules/azuread-service-principal/vars.tf
+++ b/modules/azuread-service-principal/vars.tf
@@ -9,13 +9,6 @@ variable "app_role_assignment_required" {
   default     = false
 }
 
-variable "password" {
-  description = "The password for this service principal. If this is omitted, a random password will be generated."
-  type        = string
-  default     = null
-  sensitive   = true
-}
-
 variable "end_date_relative" {
   description = "A relative duration for which the password is valid until."
   type        = string


### PR DESCRIPTION
2 modules are upgraded to use azuread provider 2.22: 
- azuread-application and 
- azuread-service-principal

There wasn't any example code for azuread-service-principal, so we add that.

Many of the changes are simply 
- changes argument names
- addition of new blocks in the azuread_application (e.g. the new `api` and `web` blocks)

However there are some more significant changes:

## azuread-application: available_to_other_tenants

This argument `available_to_other_tenants` is changed to `sign_in_audience`. And while it was previously a boolean, it is now a string, with the following possible values:
- "AzureADMyOrg" (default)
- "AzureADMultipleOrgs"
- "AzureADandPersonalMicrosoftAccount"
- "PersonalMicrosoftAccount"

## azuread-service-principal-password: password

We used to take in an optional input `password`. If `password` isn't specified, we would generate one (using the `random_password` resource).

From [v 2.0](https://github.com/hashicorp/terraform-provider-azuread/blob/main/CHANGELOG.md#200-august-26-2021) onwards, this is no longer possible. The password will be generated; it cannot be specified.
